### PR TITLE
Add CloseableHttpClient as injectable dependency

### DIFF
--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/HelloSensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/HelloSensorsAnalytics.java
@@ -13,7 +13,7 @@ public class HelloSensorsAnalytics {
 
     // DebugConsumer
     final SensorsAnalytics sa = new SensorsAnalytics(new SensorsAnalytics.DebugConsumer
-        (SA_SERVER_URL, true, null));
+        (SA_SERVER_URL, true));
     // BatchConsumer
 //    final SensorsAnalytics sa =
 //        new SensorsAnalytics(new SensorsAnalytics.BatchConsumer(SA_SERVER_URL, 10));

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/HelloSensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/HelloSensorsAnalytics.java
@@ -13,7 +13,7 @@ public class HelloSensorsAnalytics {
 
     // DebugConsumer
     final SensorsAnalytics sa = new SensorsAnalytics(new SensorsAnalytics.DebugConsumer
-        (SA_SERVER_URL, true));
+        (SA_SERVER_URL, true, null));
     // BatchConsumer
 //    final SensorsAnalytics sa =
 //        new SensorsAnalytics(new SensorsAnalytics.BatchConsumer(SA_SERVER_URL, 10));

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
@@ -78,7 +78,7 @@ public class SensorsAnalytics {
   public static class DebugConsumer implements Consumer {
 
     public DebugConsumer(final String serverUrl, final boolean writeData) {
-      this(serverUrl, writeData, getCloseableHttpClient());
+      this(serverUrl, writeData, createCloseableHttpClient());
     }
 
     public DebugConsumer(final String serverUrl, final boolean writeData, final CloseableHttpClient httpClient) {
@@ -160,12 +160,11 @@ public class SensorsAnalytics {
     }
 
     public BatchConsumer(final String serverUrl, final int bulkSize, final boolean throwException) {
-      this(serverUrl, bulkSize, 0, throwException, null);
+      this(serverUrl, bulkSize, 0, throwException, createCloseableHttpClient());
     }
 
-    public BatchConsumer(final String serverUrl, final int bulkSize,
-         final int maxCacheSize, final boolean throwException) {
-      this(serverUrl, bulkSize, maxCacheSize, throwException, getCloseableHttpClient());
+    public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize, final boolean throwException) {
+      this(serverUrl, bulkSize, maxCacheSize, throwException, createCloseableHttpClient());
     }
 
     public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize,
@@ -259,7 +258,7 @@ public class SensorsAnalytics {
 
     public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
         final ThreadPoolExecutor executor, final AsyncBatchConsumerCallback callback) {
-        this(serverUrl, bulkSize, executor, callback, getCloseableHttpClient());
+        this(serverUrl, bulkSize, executor, callback, createCloseableHttpClient());
     }
 
     public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
@@ -1415,7 +1414,7 @@ public class SensorsAnalytics {
     return jsonObjectMapper;
   }
 
-  private static CloseableHttpClient getCloseableHttpClient() {
+  private static CloseableHttpClient createCloseableHttpClient() {
     return HttpClients.custom().setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION).build();
   }
 

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
@@ -78,7 +78,7 @@ public class SensorsAnalytics {
   public static class DebugConsumer implements Consumer {
 
     public DebugConsumer(final String serverUrl, final boolean writeData) {
-      this(serverUrl, writeData, null);
+      this(serverUrl, writeData, getCloseableHttpClient());
     }
 
     public DebugConsumer(final String serverUrl, final boolean writeData, final CloseableHttpClient httpClient) {
@@ -165,7 +165,7 @@ public class SensorsAnalytics {
 
     public BatchConsumer(final String serverUrl, final int bulkSize,
          final int maxCacheSize, final boolean throwException) {
-      this(serverUrl, bulkSize, maxCacheSize, throwException, null);
+      this(serverUrl, bulkSize, maxCacheSize, throwException, getCloseableHttpClient());
     }
 
     public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize,
@@ -259,7 +259,7 @@ public class SensorsAnalytics {
 
     public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
         final ThreadPoolExecutor executor, final AsyncBatchConsumerCallback callback) {
-        this(serverUrl, bulkSize, executor, callback, null);
+        this(serverUrl, bulkSize, executor, callback, getCloseableHttpClient());
     }
 
     public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
@@ -1091,9 +1091,6 @@ public class SensorsAnalytics {
     synchronized void consume(final String data) throws IOException, HttpConsumerException {
       HttpUriRequest request = getHttpRequest(data);
       CloseableHttpResponse response = null;
-      if (httpClient == null) {
-        httpClient = HttpClients.custom().setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION).build();
-      }
       try {
         response = httpClient.execute(request);
         int httpStatusCode = response.getStatusLine().getStatusCode();
@@ -1152,7 +1149,6 @@ public class SensorsAnalytics {
       try {
         if (httpClient != null) {
           httpClient.close();
-          httpClient = null;
         }
       } catch (IOException ignored) {
         // do nothing
@@ -1419,7 +1415,11 @@ public class SensorsAnalytics {
     return jsonObjectMapper;
   }
 
-  private static final String SDK_VERSION = "3.1.17";
+  private static CloseableHttpClient getCloseableHttpClient() {
+    return HttpClients.custom().setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION).build();
+  }
+
+  public static final String SDK_VERSION = "3.1.17";
 
   private static final Pattern KEY_PATTERN = Pattern.compile(
       "^((?!^distinct_id$|^original_id$|^time$|^properties$|^id$|^first_id$|^second_id$|^users$|^events$|^event$|^user_id$|^date$|^datetime$)[a-zA-Z_$][a-zA-Z\\d_$]{0,99})$",

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
@@ -77,6 +77,10 @@ public class SensorsAnalytics {
 
   public static class DebugConsumer implements Consumer {
 
+    public DebugConsumer(final String serverUrl, final boolean writeData) {
+      this(serverUrl, writeData, null);
+    }
+
     public DebugConsumer(final String serverUrl, final boolean writeData, final CloseableHttpClient httpClient) {
       String debugUrl = null;
       try {
@@ -159,8 +163,13 @@ public class SensorsAnalytics {
       this(serverUrl, bulkSize, 0, throwException, null);
     }
 
-    public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize, final boolean throwException,
-                         final CloseableHttpClient httpClient) {
+    public BatchConsumer(final String serverUrl, final int bulkSize,
+         final int maxCacheSize, final boolean throwException) {
+      this(serverUrl, bulkSize, maxCacheSize, throwException, null);
+    }
+
+    public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize,
+         final boolean throwException, final CloseableHttpClient httpClient) {
       this.messageList = new LinkedList<Map<String, Object>>();
       this.httpConsumer = new HttpConsumer(serverUrl, null, httpClient);
       this.jsonMapper = getJsonObjectMapper();
@@ -247,6 +256,11 @@ public class SensorsAnalytics {
    */
   @Deprecated
   public static class AsyncBatchConsumer implements Consumer {
+
+    public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
+        final ThreadPoolExecutor executor, final AsyncBatchConsumerCallback callback) {
+        this(serverUrl, bulkSize, executor, callback, null);
+    }
 
     public AsyncBatchConsumer(final String serverUrl, final int bulkSize,
         final ThreadPoolExecutor executor, final AsyncBatchConsumerCallback callback,


### PR DESCRIPTION
Adds the ability to pass an Apache CloseableHttpClient as a parameter for consumers in the Library, this will allow us to pass in a pre-configured egress proxy aware HttpClient using our own `//services/httpclient:apache`. This seemed like a more sustainable approach than to start scraping the environment for proxy variables. It also seemed easier/cleaner than passing them in and constructing a client as part of the library.

Additional constructors added so that the change is not a breaking evolution for the library.

It is valid to pass null instead of a HttpClient since the library already constructs if the client does not exist.

https://github.com/sensorsdata/sa-sdk-java/blob/57ba240151918ad6cc21de68e1253e05cef356e7/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java#L1095

Upstream PR: https://github.com/sensorsdata/sa-sdk-java/pull/11